### PR TITLE
adding category blacklist

### DIFF
--- a/src/main/scala/ALSAlgorithm.scala
+++ b/src/main/scala/ALSAlgorithm.scala
@@ -158,6 +158,7 @@ class ALSAlgorithm(val ap: ALSAlgorithmParams)
         i = i,
         items = model.items,
         categories = query.categories,
+        categoryBlackList = query.categoryBlackList,
         queryList = queryList,
         whiteList = whiteList,
         blackList = blackList
@@ -218,6 +219,7 @@ class ALSAlgorithm(val ap: ALSAlgorithmParams)
     i: Int,
     items: Map[Int, Item],
     categories: Option[Set[String]],
+    categoryBlackList: Option[Set[String]],
     queryList: Set[Int],
     whiteList: Option[Set[Int]],
     blackList: Option[Set[Int]]
@@ -232,6 +234,12 @@ class ALSAlgorithm(val ap: ALSAlgorithmParams)
         // keep this item if has ovelap categories with the query
         !(itemCat.toSet.intersect(cat).isEmpty)
       }.getOrElse(false) // discard this item if it has no categories
+    }.getOrElse(true) &&
+    categoryBlackList.map { cat =>
+      items(i).categories.map { itemCat =>
+        // discard this item if has ovelap categories with the query
+        (itemCat.toSet.intersect(cat).isEmpty)
+      }.getOrElse(true) // keep this item if it has no categories
     }.getOrElse(true)
   }
 

--- a/src/main/scala/Engine.scala
+++ b/src/main/scala/Engine.scala
@@ -7,6 +7,7 @@ case class Query(
   items: List[String],
   num: Int,
   categories: Option[Set[String]],
+  categoryBlackList: Option[Set[String]],
   whiteList: Option[Set[String]],
   blackList: Option[Set[String]]
 ) extends Serializable


### PR DESCRIPTION
resolve #7 

Did a simple test and it seems to work fine. 

Not sure what the desired behavior is for items without categories if both category blacklist and whitelist are used. In the original code items without categories were rejected if a category whitelist was used.

**Setup**

``` bash
$python data/import_eventserver.py --access_key $ACCESS_KEY

$pio build
$pio train
$pio deploy
```

**Check Regular Output**

``` bash
$ curl -H "Content-Type: application/json" -d '{ "items": ["i1"], "num": 2}' http://localhost:8000/queries.json
{"itemScores":[{"item":"i21","score":0.5954677866335736},{"item":"i43","score":0.5954677866335736}]}
```

**Check Categories on Returned Items**

``` bash
$curl -i -X GET "http://localhost:7070/events.json?accessKey=$ACCESS_KEY&entityId=i21"
[{"eventId":"ju3PNXbdlFIVrJvllSFn6AAAAVOzFictgvPavEwQRrg","event":"$set","entityType":"item","entityId":"i21","properties":{"categories":["c4"]},"eventTime":"2016-03-26T13:21:26.829Z","creationTime":"2016-03-26T13:21:26.831Z"}]

$curl -i -X GET "http://localhost:7070/events.json?accessKey=$ACCESS_KEYf&entityId=i43"
[{"eventId":"hofam3kIHfr4DiXaRggbZwAAAVOzFifPhpy0OKJE8d4","event":"$set","entityType":"item","entityId":"i43","properties":{"categories":["c2"]},"eventTime":"2016-03-26T13:21:26.991Z","creationTime":"2016-03-26T13:21:26.994Z"}]
```

**Blacklist Categories**

``` bash
$curl -H "Content-Type: application/json" -d '{ "items": ["i1"], "num": 2,"categoryBlackList":["c4"]}' http://localhost:8000/queries.json
{"itemScores":[{"item":"i43","score":0.5954677866335736},{"item":"i3","score":0.4273817248904073}]}

$curl -H "Content-Type: application/json" -d '{ "items": ["i1"], "num": 2,"categoryBlackList":["c2"]}' http://localhost:8000/queries.json
{"itemScores":[{"item":"i21","score":0.5954677866335736},{"item":"i3","score":0.4273817248904073}]}

$curl -H "Content-Type: application/json" -d '{ "items": ["i1"], "num": 2,"categoryBlackList":["c2","c4"]}' http://localhost:8000/queries.json
{"itemScores":[{"item":"i3","score":0.4273817248904073},{"item":"i8","score":0.40949795974796405}]}
```
